### PR TITLE
moved hide call for cluebar to include entire cluebar. 

### DIFF
--- a/toggleclues.js
+++ b/toggleclues.js
@@ -3,7 +3,8 @@ console.log("in toggleclues");
 var clues = document.getElementsByClassName("ClueList-wrapper--3m-kd");
 console.log("clues length is " + clues.length);
 
-var clueBar = document.getElementsByClassName("ClueBar-text--1fYP2");
+//var clueBar = document.getElementsByClassName("ClueBar-text--1fYP2");
+var clueBar = document.getElementsByClassName("ClueBar-bar--2RGEq");
 console.log("cluebar's length is " + clueBar.length);
 
 console.log("visibility is " + window.getComputedStyle(clues[clue], null).getPropertyValue('visibility'));


### PR DESCRIPTION
When I did this previously it messed with the housing of the entire grid and left it shrunk in size. As this no longer seems to be the case, I moved the hide call to the cluebar, so that now you can toggle-hide the clues before hitting the "ready to go" button to get it to load first, which was an unsatisfactory experience