### PR TITLE
Add options

### DIFF
--- a/autorun.js
+++ b/autorun.js
@@ -1,70 +1,89 @@
 window.onload=function(){
   console.log("super duper page load!");
   
-  
-  var ads = document.getElementsByClassName("Ad-ad--25EEa Ad-fluid--3MBcp");
-  console.log("ads length is " + ads.length);
-  adsNo = ads.length;
+  // remove ads section if in userpreferences
+  chrome.storage.local.get("removeAds", function(data) {
+    if (data.removeAds) {
+      var ads = document.getElementsByClassName("Ad-ad--25EEa Ad-fluid--3MBcp");
+      console.log("ads length is " + ads.length);
+      adsNo = ads.length;
 
-  // ads section
-  for (var i = ads.length - 1; i > -1; i--) {
-	  console.log("loop for " + i);
-	  ads[i].parentNode.removeChild(ads[i]);
-  // 	console.log(ads[i]);
-	  console.log("completed child removal, i is " + i);
-  };
+      for (var i = ads.length - 1; i > -1; i--) {
+        console.log("loop for " + i);
+        ads[i].parentNode.removeChild(ads[i]);
+      // 	console.log(ads[i]);
+        console.log("completed child removal, i is " + i);
+      };
   
-  var sup = document.getElementsByClassName("SponsoredBanner-supportedBy--x59D3 hide-on-print");
-  console.log("sup length is " + sup.length);
-  if (sup.length > 0) {
-    sup[0].parentNode.removeChild(sup[0]);
-  };
+      var sup = document.getElementsByClassName("SponsoredBanner-supportedBy--x59D3 hide-on-print");
+      console.log("sup length is " + sup.length);
+      if (sup.length > 0) {
+        sup[0].parentNode.removeChild(sup[0]);
+      };
   
-  var sup2 = document.getElementsByClassName("SponsoredCard-supportedBy--MAPI8");
-  console.log("sup2 length is " + sup2.length);
-  if (sup2.length > 0) {
-    sup2[0].parentNode.removeChild(sup2[0]);
-  };
+      var sup2 = document.getElementsByClassName("SponsoredCard-supportedBy--MAPI8");
+      console.log("sup2 length is " + sup2.length);
+      if (sup2.length > 0) {
+        sup2[0].parentNode.removeChild(sup2[0]);
+      };
   
-  // this is for the acrostic
-  var ac_ads = document.getElementsByClassName("pz-section pz-section-filled pz-ad-box");
-  console.log("ac_ads length is " + ac_ads.length);
-  for (var i = ac_ads.length - 1; i > -1; i--) {
-    ac_ads[i].parentNode.removeChild(ac_ads[i]);
-  };
+      // this is for the acrostic
+      var ac_ads = document.getElementsByClassName("pz-section pz-section-filled pz-ad-box");
+      console.log("ac_ads length is " + ac_ads.length);
+      for (var i = ac_ads.length - 1; i > -1; i--) {
+        ac_ads[i].parentNode.removeChild(ac_ads[i]);
+      };
+    };
+  });
 
   // alternate puzzles carousel
-  var car = document.getElementsByClassName("AlternatePuzzles-alternatePuzzles--2FGMm");
-  console.log("carousel length is " + car.length);
-  if (car.length > 0) {
-    car[0].parentNode.removeChild(car[0]);
-  };
+  chrome.storage.local.get("removeCarousel", function(data) {
+    if (data.removeCarousel) {
+      var car = document.getElementsByClassName("AlternatePuzzles-alternatePuzzles--2FGMm");
+      console.log("carousel length is " + car.length);
+      if (car.length > 0) {
+        car[0].parentNode.removeChild(car[0]);
+      };
+    };
+  });
   
   // wordplay
-  var wp = document.getElementsByClassName("SubGameplayGrid-subGameplayGrid--2OEdn");
-  console.log("wp length is " + wp.length);
-  if (wp.length > 0) {
-    wp[0].parentNode.removeChild(wp[0]);
-  };
+  chrome.storage.local.get("removeWordplay", function(data) {
+    if (data.removeWordplay) {
+      var wp = document.getElementsByClassName("SubGameplayGrid-subGameplayGrid--2OEdn");
+      console.log("wp length is " + wp.length);
+      if (wp.length > 0) {
+        wp[0].parentNode.removeChild(wp[0]);
+      };
+    };
+  });
 
   // sitemap
-  var foot = document.getElementsByClassName("Footer-footerWrapper--3AHd0");
-  console.log("foot length is " + foot.length);
-  if (foot.length > 0) {
-    foot[0].parentNode.removeChild(foot[0]);
-  };
+  chrome.storage.local.get("removeSitemap", function(data) {
+    if (data.removeSitemap) {
+      var foot = document.getElementsByClassName("Footer-footerWrapper--3AHd0");
+      console.log("foot length is " + foot.length);
+      if (foot.length > 0) {
+        foot[0].parentNode.removeChild(foot[0]);
+      };
   
-  // sitemap for acrostic
-  var ac_foot = document.getElementsByClassName("pz-footer");
-  console.log("ac_foot length is " + ac_foot.length);
-  if (ac_foot.length > 0) {
-    ac_foot[0].parentNode.removeChild(ac_foot[0]);
-  };
+      // sitemap for acrostic
+      var ac_foot = document.getElementsByClassName("pz-footer");
+      console.log("ac_foot length is " + ac_foot.length);
+      if (ac_foot.length > 0) {
+        ac_foot[0].parentNode.removeChild(ac_foot[0]);
+      };
+    };
+  });
 
   // print and download buttons
-  var print = document.getElementsByClassName("ButtonBar-wrapper--3Cm-R");
-  console.log("print length is " + print.length);
-  if (print.length > 0) {  
-    print[0].parentNode.removeChild(print[0]);
-  };  
+  chrome.storage.local.get("removeButtons", function(data) {
+    if (data.removeButtons) {
+      var print = document.getElementsByClassName("ButtonBar-wrapper--3Cm-R");
+      console.log("print length is " + print.length);
+      if (print.length > 0) {  
+        print[0].parentNode.removeChild(print[0]);
+      };  
+    };
+  });
 }

--- a/autorun.js
+++ b/autorun.js
@@ -1,45 +1,23 @@
 window.onload=function(){
   console.log("super duper page load!");
+  
+  
   var ads = document.getElementsByClassName("Ad-ad--25EEa Ad-fluid--3MBcp");
   console.log("ads length is " + ads.length);
-
   adsNo = ads.length;
 
+  // ads section
   for (var i = ads.length - 1; i > -1; i--) {
 	  console.log("loop for " + i);
 	  ads[i].parentNode.removeChild(ads[i]);
   // 	console.log(ads[i]);
 	  console.log("completed child removal, i is " + i);
   };
-
-  var car = document.getElementsByClassName("AlternatePuzzles-alternatePuzzles--2FGMm");
-  console.log("carousel length is " + car.length);
-  if (car.length > 0) {
-    car[0].parentNode.removeChild(car[0]);
-  };
-
+  
   var sup = document.getElementsByClassName("SponsoredBanner-supportedBy--x59D3 hide-on-print");
   console.log("sup length is " + sup.length);
   if (sup.length > 0) {
     sup[0].parentNode.removeChild(sup[0]);
-  };
-  
-  var wp = document.getElementsByClassName("SubGameplayGrid-subGameplayGrid--2OEdn");
-  console.log("wp length is " + wp.length);
-  if (wp.length > 0) {
-    wp[0].parentNode.removeChild(wp[0]);
-  };
-
-  var foot = document.getElementsByClassName("Footer-footerWrapper--3AHd0");
-  console.log("foot length is " + foot.length);
-  if (foot.length > 0) {
-    foot[0].parentNode.removeChild(foot[0]);
-  };
-
-  var print = document.getElementsByClassName("ButtonBar-wrapper--3Cm-R");
-  console.log("print length is " + print.length);
-  if (print.length > 0) {  
-    print[0].parentNode.removeChild(print[0]);
   };
   
   var sup2 = document.getElementsByClassName("SponsoredCard-supportedBy--MAPI8");
@@ -48,16 +26,45 @@ window.onload=function(){
     sup2[0].parentNode.removeChild(sup2[0]);
   };
   
+  // this is for the acrostic
   var ac_ads = document.getElementsByClassName("pz-section pz-section-filled pz-ad-box");
   console.log("ac_ads length is " + ac_ads.length);
   for (var i = ac_ads.length - 1; i > -1; i--) {
     ac_ads[i].parentNode.removeChild(ac_ads[i]);
   };
+
+  // alternate puzzles carousel
+  var car = document.getElementsByClassName("AlternatePuzzles-alternatePuzzles--2FGMm");
+  console.log("carousel length is " + car.length);
+  if (car.length > 0) {
+    car[0].parentNode.removeChild(car[0]);
+  };
   
+  // wordplay
+  var wp = document.getElementsByClassName("SubGameplayGrid-subGameplayGrid--2OEdn");
+  console.log("wp length is " + wp.length);
+  if (wp.length > 0) {
+    wp[0].parentNode.removeChild(wp[0]);
+  };
+
+  // sitemap
+  var foot = document.getElementsByClassName("Footer-footerWrapper--3AHd0");
+  console.log("foot length is " + foot.length);
+  if (foot.length > 0) {
+    foot[0].parentNode.removeChild(foot[0]);
+  };
+  
+  // sitemap for acrostic
   var ac_foot = document.getElementsByClassName("pz-footer");
   console.log("ac_foot length is " + ac_foot.length);
   if (ac_foot.length > 0) {
     ac_foot[0].parentNode.removeChild(ac_foot[0]);
   };
-  
+
+  // print and download buttons
+  var print = document.getElementsByClassName("ButtonBar-wrapper--3Cm-R");
+  console.log("print length is " + print.length);
+  if (print.length > 0) {  
+    print[0].parentNode.removeChild(print[0]);
+  };  
 }

--- a/background.js
+++ b/background.js
@@ -5,6 +5,8 @@ chrome.extension.getBackgroundPage().console.log("bgjs");
 chrome.runtime.onInstalled.addListener(function() {
   chrome.storage.onChanged.addListener(function(changes, namespace) {
 	console.log("in onChanged");
+	
+	// general reporting of what changed
 	for (var key in changes) {
 	  var storageChange = changes[key];
 	  console.log('Storage key "%s" in namespace "%s" changed. ' +
@@ -13,6 +15,12 @@ chrome.runtime.onInstalled.addListener(function() {
 				  namespace,
 				  storageChange.oldValue,
 				  storageChange.newValue);
+	  
+	  //
+	  // this section is all about toggling clue visibility
+	  //
+	  
+	  // initializing clue to affect across by default
 	  var clue = 0;
 	  
 	  if (key == "acrossVisible") {
@@ -41,11 +49,27 @@ chrome.runtime.onInstalled.addListener(function() {
           );  
         });      
       });
+      
+      //
+      // This section is about what is removed from the page on load, from the options section
+      //
+      
 	}
   });
 
+  
+  // on install, set all clues to visible by default
+  // this is stored locally as it is assumed players will not want it persisted
   chrome.storage.local.set({acrossVisible: true});
   chrome.storage.local.set({downVisible: true});
+  
+  // on install, set all sections to be removed by default
+  // this is set globally as it assumes players will desire consistency across browsers
+  chrome.storage.sync.set({removeAds: true});
+  chrome.storage.sync.set({removeSitemap: true});
+  chrome.storage.sync.set({removeCarousel: true});
+  chrome.storage.sync.set({removeWordplay: true});
+  chrome.storage.sync.set({removeButtons: true});  
   
   chrome.declarativeContent.onPageChanged.removeRules(undefined, function() {
 	var isNyt = {

--- a/background.js
+++ b/background.js
@@ -67,7 +67,7 @@ chrome.runtime.onInstalled.addListener(function() {
   chrome.storage.local.set({removeSitemap: true});
   chrome.storage.local.set({removeCarousel: true});
   chrome.storage.local.set({removeWordplay: true});
-  chrome.storage.local.set({removeButtons: true});  
+  chrome.storage.local.set({removeButtons: false});  
   
   chrome.declarativeContent.onPageChanged.removeRules(undefined, function() {
 	var isNyt = {

--- a/background.js
+++ b/background.js
@@ -59,17 +59,15 @@ chrome.runtime.onInstalled.addListener(function() {
 
   
   // on install, set all clues to visible by default
-  // this is stored locally as it is assumed players will not want it persisted
   chrome.storage.local.set({acrossVisible: true});
   chrome.storage.local.set({downVisible: true});
   
   // on install, set all sections to be removed by default
-  // this is set globally as it assumes players will desire consistency across browsers
-  chrome.storage.sync.set({removeAds: true});
-  chrome.storage.sync.set({removeSitemap: true});
-  chrome.storage.sync.set({removeCarousel: true});
-  chrome.storage.sync.set({removeWordplay: true});
-  chrome.storage.sync.set({removeButtons: true});  
+  chrome.storage.local.set({removeAds: true});
+  chrome.storage.local.set({removeSitemap: true});
+  chrome.storage.local.set({removeCarousel: true});
+  chrome.storage.local.set({removeWordplay: true});
+  chrome.storage.local.set({removeButtons: true});  
   
   chrome.declarativeContent.onPageChanged.removeRules(undefined, function() {
 	var isNyt = {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Cross words with crosswords",
   "version": "1.1",
-   "permissions": ["activeTab", "declarativeContent", "storage"],
+  "permissions": ["activeTab", "declarativeContent", "storage"],
   "description": "fix the ugly",
   "background": {
 	"scripts": ["background.js"],

--- a/options.html
+++ b/options.html
@@ -1,11 +1,32 @@
 <!DOCTYPE html>
 <html>
   <body>
-    <input type="checkbox" id="removeAds"> Remove all ads from page<br>
-    <input type="checkbox" id="removeSitemap"> Remove the sitemap section<br>
-    <input type="checkbox" id="removeCarousel"> Remove the alternate puzzles Carousel<br>
-    <input type="checkbox" id="removeWordplay"> Remove the Wordplay section <br>
-    <input type="checkbox" id="removeButtons"> Remove the print/download buttons <br>
+    <div class="data">    
+    <span>
+    <input id="removeAds" type="checkbox" value="removeAds"/>
+    <label for="employee">Remove all ads from page <br></label>
+    </span> 
+    
+    <span>
+    <input id="removeSitemap" type="checkbox" value="removeSitemap"/>
+    <label for="employee">Remove sitemap section<br></label>
+    </span> 
+    
+    <span>
+    <input id="removeCarousel" type="checkbox" value="removeCarousel"/>
+    <label for="employee">Remove the alternate puzzles carousel<br></label>
+    </span> 
+
+    <span>
+    <input id="removeWordplay" type="checkbox" value="removeWordplay"/>
+    <label for="employee">Remove the Wordplay section<br></label>
+    </span> 
+    
+    <span>
+    <input id="removeButtons" type="checkbox" value="removeButtons"/>
+    <label for="employee">Remove the print/download buttons<br></label>
+    </span>     
+    </div>
     <script src="options.js"></script>
   </body>  
 </html>

--- a/options.html
+++ b/options.html
@@ -1,18 +1,11 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <style>
-      button {
-        height: 30px;
-        width: 30px;
-        outline: none;
-        margin: 10px;
-      }
-    </style>
-  </head>
   <body>
-    <div id="buttonDiv">
-    </div>
-  </body>
-  <script src="options.js"></script>
+    <input type="checkbox" id="removeAds"> Remove all ads from page<br>
+    <input type="checkbox" id="removeSitemap"> Remove the sitemap section<br>
+    <input type="checkbox" id="removeCarousel"> Remove the alternate puzzles Carousel<br>
+    <input type="checkbox" id="removeWordplay"> Remove the Wordplay section <br>
+    <input type="checkbox" id="removeButtons"> Remove the print/download buttons <br>
+    <script src="options.js"></script>
+  </body>  
 </html>

--- a/options.html
+++ b/options.html
@@ -1,31 +1,31 @@
 <!DOCTYPE html>
 <html>
   <body>
-    <div class="data">    
-    <span>
-    <input id="removeAds" type="checkbox" value="removeAds"/>
-    <label for="employee">Remove all ads from page <br></label>
-    </span> 
-    
-    <span>
-    <input id="removeSitemap" type="checkbox" value="removeSitemap"/>
-    <label for="employee">Remove sitemap section<br></label>
-    </span> 
-    
-    <span>
-    <input id="removeCarousel" type="checkbox" value="removeCarousel"/>
-    <label for="employee">Remove the alternate puzzles carousel<br></label>
-    </span> 
+    <div id="options">    
+      <span>
+      <input id="option" type="checkbox" value="removeAds"/>
+      <label for="employee">Remove all ads from page <br></label>
+      </span> 
+  
+      <span>
+      <input id="option" type="checkbox" value="removeSitemap"/>
+      <label for="employee">Remove sitemap section<br></label>
+      </span> 
+  
+      <span>
+      <input id="option" type="checkbox" value="removeCarousel"/>
+      <label for="employee">Remove the alternate puzzles carousel<br></label>
+      </span> 
 
-    <span>
-    <input id="removeWordplay" type="checkbox" value="removeWordplay"/>
-    <label for="employee">Remove the Wordplay section<br></label>
-    </span> 
-    
-    <span>
-    <input id="removeButtons" type="checkbox" value="removeButtons"/>
-    <label for="employee">Remove the print/download buttons<br></label>
-    </span>     
+      <span>
+      <input id="option" type="checkbox" value="removeWordplay"/>
+      <label for="employee">Remove the Wordplay section<br></label>
+      </span> 
+  
+      <span>
+      <input id="option" type="checkbox" value="removeButtons"/>
+      <label for="employee">Remove the print/download buttons<br></label>
+      </span>     
     </div>
     <script src="options.js"></script>
   </body>  

--- a/options.js
+++ b/options.js
@@ -4,14 +4,32 @@
 
 'use strict';
 
-let removeAds = document.getElementById('removeAds');
-let removeSitemap = document.getElementById('removeSitemap');
-let removeCarousel = document.getElementById('removeCarousel');
-let removeWordplay = document.getElementById('removeWordplay');
-let removeButtons = document.getElementById('removeButtons');
+// let removeAds = document.getElementById('removeAds');
+// let removeSitemap = document.getElementById('removeSitemap');
+// let removeCarousel = document.getElementById('removeCarousel');
+// let removeWordplay = document.getElementById('removeWordplay');
+// let removeButtons = document.getElementById('removeButtons');
 
 
 chrome.extension.getBackgroundPage().console.log("in options");
+
+var el = document.getElementById('options');
+console.log("el looks like this: " + el);
+
+
+var boxes = el.getElementsByTagName('input');
+console.log("boxes looks like this: " + boxes);
+
+for (var i=0, len=boxes.length; i<len; i++) {
+  if ( boxes[i].type === 'checkbox' ) {
+    boxes[i].onclick = logClick;    
+  };
+};
+
+function logClick(box) {
+  console.log("this looks like " + this);
+  console.log("and has the value " + this.value);
+};
 
 // removeAds.onclick = function(element) {
 // 	chrome.extension.getBackgroundPage().console.log("in toggleAcross");
@@ -26,55 +44,38 @@ chrome.extension.getBackgroundPage().console.log("in options");
 // 	}
 // 	chrome.extension.getBackgroundPage().console.log("after call");
 // };
-// 
-// let toggleDown = document.getElementById('toggleDown');
-// 
-// toggleDown.onclick = function(element) {
-// 	chrome.extension.getBackgroundPage().console.log("in toggleDown");
-// 	try {
-// 	  chrome.storage.local.get("downVisible", function(data) {
-//         chrome.storage.local.set({downVisible: !data.downVisible});
-//         console.log("setting downVisible to " + !data.downVisible);
-//       });
-//       chrome.extension.getBackgroundPage().console.log("clicked toggle-down");
-// 	} catch(err) {
-// 		chrome.extension.getBackgroundPage().console.log(err);
-// 	}
-// 	chrome.extension.getBackgroundPage().console.log("after call");
-// };
-// 
 
 
 // initialize all boxes to be checked according to stored values
-function refreshOptionsChecks() {
-  chrome.extension.getBackgroundPage().console.log("in refreshOptionsChecks");
-
-  chrome.storage.local.get("removeAds", function(data) {
-    chrome.extension.getBackgroundPage().console.log("removeAds is " + data.removeAds);
-    removeAds.checked = data.removeAds;    
-  });
-
-  chrome.storage.local.get("removeSitemap", function(data) {
-    chrome.extension.getBackgroundPage().console.log("removeSitemap is " + data.removeSitemap);
-    removeSitemap.checked = data.removeSitemap;
-  });
-    chrome.storage.local.get("removeCarousel", function(data) {
-    chrome.extension.getBackgroundPage().console.log("removeCarousel is " + data.removeCarousel);
-    removeCarousel.checked = data.removeCarousel;
-  });
-
-  chrome.storage.local.get("removeWordplay", function(data) {
-    chrome.extension.getBackgroundPage().console.log("removeWordplay is " + data.removeWordplay);
-    removeWordplay.checked = data.removeWordplay;
-  });
-
-  chrome.storage.local.get("removeButtons", function(data) {
-    chrome.extension.getBackgroundPage().console.log("removeButtons is " + data.removeButtons);
-    removeButtons.checked = data.removeButtons;
-  });
-
-};
-
-window.addEventListener ? 
-window.addEventListener("load", refreshOptionsChecks, false) : 
-window.attachEvent && window.attachEvent("onload", refreshOptionsChecks);
+// function refreshOptionsChecks() {
+//   chrome.extension.getBackgroundPage().console.log("in refreshOptionsChecks");
+// 
+//   chrome.storage.local.get("removeAds", function(data) {
+//     chrome.extension.getBackgroundPage().console.log("removeAds is " + data.removeAds);
+//     removeAds.checked = data.removeAds;    
+//   });
+// 
+//   chrome.storage.local.get("removeSitemap", function(data) {
+//     chrome.extension.getBackgroundPage().console.log("removeSitemap is " + data.removeSitemap);
+//     removeSitemap.checked = data.removeSitemap;
+//   });
+//     chrome.storage.local.get("removeCarousel", function(data) {
+//     chrome.extension.getBackgroundPage().console.log("removeCarousel is " + data.removeCarousel);
+//     removeCarousel.checked = data.removeCarousel;
+//   });
+// 
+//   chrome.storage.local.get("removeWordplay", function(data) {
+//     chrome.extension.getBackgroundPage().console.log("removeWordplay is " + data.removeWordplay);
+//     removeWordplay.checked = data.removeWordplay;
+//   });
+// 
+//   chrome.storage.local.get("removeButtons", function(data) {
+//     chrome.extension.getBackgroundPage().console.log("removeButtons is " + data.removeButtons);
+//     removeButtons.checked = data.removeButtons;
+//   });
+// 
+// };
+// 
+// window.addEventListener ? 
+// window.addEventListener("load", refreshOptionsChecks, false) : 
+// window.attachEvent && window.attachEvent("onload", refreshOptionsChecks);

--- a/options.js
+++ b/options.js
@@ -4,8 +4,9 @@
 
 'use strict';
 
-chrome.extension.getBackgroundPage().console.log("in options");
+console.log("in options");
 
+// assign click functionality to options checkboxes
 var el = document.getElementById('options');
 var boxes = el.getElementsByTagName('input');
 
@@ -15,24 +16,15 @@ for (var i=0, len=boxes.length; i<len; i++) {
   };
 };
 
+// store user selections
 function logClick(box) {
-  console.log("this looks like " + this);
-  console.log("and has the value " + this.value);
+  var which = this.value;
+  var remove = this.checked;
+  console.log("setting " + which + " to " + remove);
+  var obj = {};
+  obj[which] = remove;
+  chrome.storage.local.set(obj);
 };
-
-// removeAds.onclick = function(element) {
-// 	chrome.extension.getBackgroundPage().console.log("in toggleAcross");
-// 	try {
-// 	  chrome.storage.local.get("acrossVisible", function(data) {
-//         chrome.storage.local.set({acrossVisible: !data.acrossVisible});
-//         console.log("setting acrossVisible to " + !data.acrossVisible);
-//       });	  
-//       chrome.extension.getBackgroundPage().console.log("clicked toggle-across");
-// 	} catch(err) {
-// 		chrome.extension.getBackgroundPage().console.log(err);
-// 	}
-// 	chrome.extension.getBackgroundPage().console.log("after call");
-// };
 
 
 //initialize all boxes to be checked according to stored values

--- a/options.js
+++ b/options.js
@@ -4,20 +4,77 @@
 
 'use strict';
 
-let page = document.getElementById('buttonDiv');
+let removeAds = document.getElementById('removeAds');
+let removeSitemap = document.getElementById('removeSitemap');
+let removeCarousel = document.getElementById('removeCarousel');
+let removeWordplay = document.getElementById('removeWordplay');
+let removeButtons = document.getElementById('removeButtons');
 
-const kButtonColors = ['#3aa757', '#e8453c', '#f9bb2d', '#4688f1'];
 
-function constructOptions(kButtonColors) {
-  for (let item of kButtonColors) {
-    let button = document.createElement('button');
-    button.style.backgroundColor = item;
-    button.addEventListener('click', function() {
-      chrome.storage.sync.set({color: item}, function() {
-        console.log('color is ' + item);
-      })
-    });
-    page.appendChild(button);
-  }
-}
-constructOptions(kButtonColors);
+chrome.extension.getBackgroundPage().console.log("in options");
+
+// removeAds.onclick = function(element) {
+// 	chrome.extension.getBackgroundPage().console.log("in toggleAcross");
+// 	try {
+// 	  chrome.storage.local.get("acrossVisible", function(data) {
+//         chrome.storage.local.set({acrossVisible: !data.acrossVisible});
+//         console.log("setting acrossVisible to " + !data.acrossVisible);
+//       });	  
+//       chrome.extension.getBackgroundPage().console.log("clicked toggle-across");
+// 	} catch(err) {
+// 		chrome.extension.getBackgroundPage().console.log(err);
+// 	}
+// 	chrome.extension.getBackgroundPage().console.log("after call");
+// };
+// 
+// let toggleDown = document.getElementById('toggleDown');
+// 
+// toggleDown.onclick = function(element) {
+// 	chrome.extension.getBackgroundPage().console.log("in toggleDown");
+// 	try {
+// 	  chrome.storage.local.get("downVisible", function(data) {
+//         chrome.storage.local.set({downVisible: !data.downVisible});
+//         console.log("setting downVisible to " + !data.downVisible);
+//       });
+//       chrome.extension.getBackgroundPage().console.log("clicked toggle-down");
+// 	} catch(err) {
+// 		chrome.extension.getBackgroundPage().console.log(err);
+// 	}
+// 	chrome.extension.getBackgroundPage().console.log("after call");
+// };
+// 
+
+
+// initialize all boxes to be checked according to stored values
+function refreshOptionsChecks() {
+  chrome.extension.getBackgroundPage().console.log("in refreshOptionsChecks");
+
+  chrome.storage.local.get("removeAds", function(data) {
+    chrome.extension.getBackgroundPage().console.log("removeAds is " + data.removeAds);
+    removeAds.checked = data.removeAds;    
+  });
+
+  chrome.storage.local.get("removeSitemap", function(data) {
+    chrome.extension.getBackgroundPage().console.log("removeSitemap is " + data.removeSitemap);
+    removeSitemap.checked = data.removeSitemap;
+  });
+    chrome.storage.local.get("removeCarousel", function(data) {
+    chrome.extension.getBackgroundPage().console.log("removeCarousel is " + data.removeCarousel);
+    removeCarousel.checked = data.removeCarousel;
+  });
+
+  chrome.storage.local.get("removeWordplay", function(data) {
+    chrome.extension.getBackgroundPage().console.log("removeWordplay is " + data.removeWordplay);
+    removeWordplay.checked = data.removeWordplay;
+  });
+
+  chrome.storage.local.get("removeButtons", function(data) {
+    chrome.extension.getBackgroundPage().console.log("removeButtons is " + data.removeButtons);
+    removeButtons.checked = data.removeButtons;
+  });
+
+};
+
+window.addEventListener ? 
+window.addEventListener("load", refreshOptionsChecks, false) : 
+window.attachEvent && window.attachEvent("onload", refreshOptionsChecks);

--- a/options.js
+++ b/options.js
@@ -4,21 +4,10 @@
 
 'use strict';
 
-// let removeAds = document.getElementById('removeAds');
-// let removeSitemap = document.getElementById('removeSitemap');
-// let removeCarousel = document.getElementById('removeCarousel');
-// let removeWordplay = document.getElementById('removeWordplay');
-// let removeButtons = document.getElementById('removeButtons');
-
-
 chrome.extension.getBackgroundPage().console.log("in options");
 
 var el = document.getElementById('options');
-console.log("el looks like this: " + el);
-
-
 var boxes = el.getElementsByTagName('input');
-console.log("boxes looks like this: " + boxes);
 
 for (var i=0, len=boxes.length; i<len; i++) {
   if ( boxes[i].type === 'checkbox' ) {
@@ -46,36 +35,24 @@ function logClick(box) {
 // };
 
 
-// initialize all boxes to be checked according to stored values
-// function refreshOptionsChecks() {
-//   chrome.extension.getBackgroundPage().console.log("in refreshOptionsChecks");
-// 
-//   chrome.storage.local.get("removeAds", function(data) {
-//     chrome.extension.getBackgroundPage().console.log("removeAds is " + data.removeAds);
-//     removeAds.checked = data.removeAds;    
-//   });
-// 
-//   chrome.storage.local.get("removeSitemap", function(data) {
-//     chrome.extension.getBackgroundPage().console.log("removeSitemap is " + data.removeSitemap);
-//     removeSitemap.checked = data.removeSitemap;
-//   });
-//     chrome.storage.local.get("removeCarousel", function(data) {
-//     chrome.extension.getBackgroundPage().console.log("removeCarousel is " + data.removeCarousel);
-//     removeCarousel.checked = data.removeCarousel;
-//   });
-// 
-//   chrome.storage.local.get("removeWordplay", function(data) {
-//     chrome.extension.getBackgroundPage().console.log("removeWordplay is " + data.removeWordplay);
-//     removeWordplay.checked = data.removeWordplay;
-//   });
-// 
-//   chrome.storage.local.get("removeButtons", function(data) {
-//     chrome.extension.getBackgroundPage().console.log("removeButtons is " + data.removeButtons);
-//     removeButtons.checked = data.removeButtons;
-//   });
-// 
-// };
-// 
-// window.addEventListener ? 
-// window.addEventListener("load", refreshOptionsChecks, false) : 
-// window.attachEvent && window.attachEvent("onload", refreshOptionsChecks);
+//initialize all boxes to be checked according to stored values
+function refreshOptionsChecks() {  
+  var el = document.getElementById('options');  
+  var boxes = el.getElementsByTagName('input');  
+  for (var i=0, len=boxes.length; i<len; i++) {
+    if ( boxes[i].type === 'checkbox' ) {
+      initiateBox(boxes[i]);
+    };
+  };
+};
+
+function initiateBox(box) {
+  var which = box.value;
+  chrome.storage.local.get(which, function(data) {
+    box.checked = data[which];
+  });
+};
+
+window.addEventListener ? 
+window.addEventListener("load", refreshOptionsChecks, false) : 
+window.attachEvent && window.attachEvent("onload", refreshOptionsChecks);


### PR DESCRIPTION
This refactors the options page to be useful instead of a placeholder. It is only focused on what is removed by default from the pages. It is separated into 5 options, the first 4 of which are selected by default. Ads, Sitemap, Wordplay, Alternate puzzles carousel, and the download and print button pair (off by default).

I think it could use some visual guidance, I'm thinking either screenshots or animated gifs or something to give visual meaning to the selections, as it is hard to make clear what exactly it is affecting.  Additionally, there is now an error when writing to google storage from the Options page, having to do with permissions. While this doesn't affect functionality, it does seem crufty and should probably be fixed.