### PR TITLE
drying out the popup

### DIFF
--- a/options.html
+++ b/options.html
@@ -4,27 +4,27 @@
     <div id="options">    
       <span>
       <input id="option" type="checkbox" value="removeAds"/>
-      <label for="employee">Remove all ads from page <br></label>
+      <label for="option">Remove all ads from page <br></label>
       </span> 
   
       <span>
       <input id="option" type="checkbox" value="removeSitemap"/>
-      <label for="employee">Remove sitemap section<br></label>
+      <label for="option">Remove sitemap section<br></label>
       </span> 
   
       <span>
       <input id="option" type="checkbox" value="removeCarousel"/>
-      <label for="employee">Remove the alternate puzzles carousel<br></label>
+      <label for="option">Remove the alternate puzzles carousel<br></label>
       </span> 
 
       <span>
       <input id="option" type="checkbox" value="removeWordplay"/>
-      <label for="employee">Remove the Wordplay section<br></label>
+      <label for="option">Remove the Wordplay section<br></label>
       </span> 
   
       <span>
       <input id="option" type="checkbox" value="removeButtons"/>
-      <label for="employee">Remove the print/download buttons<br></label>
+      <label for="option">Remove the print/download buttons<br></label>
       </span>     
     </div>
     <script src="options.js"></script>

--- a/popup.html
+++ b/popup.html
@@ -1,8 +1,16 @@
 <!DOCTYPE html>
 <html style="min-width:200px;">
   <body>
-    <input type="checkbox" id="toggleAcross"> Show/hide across clues<br>(cmd+shift+A)<br>
-    <input type="checkbox" id="toggleDown"> Show/hide down clues<br>(cmd+shift+L)<br>
+    <div id="toggles">
+      <span>
+      <input id="toggle" type="checkbox" value="acrossVisible"/>
+      <label for="toggle">Hide across clues<br>(cmd+shift+A)<br></label>
+      </span> 
+      <span>
+      <input id="toggle" type="checkbox" value="downVisible"/>
+      <label for="toggle">Hide down clues<br>(cmd+shift+L)<br></label>
+      </span> 
+    </div>
     Toggle pencil with cmd+0
     <script src="popup.js"></script>
   </body>

--- a/popup.js
+++ b/popup.js
@@ -4,49 +4,39 @@
 
 'use strict';
 
-let toggleAcross = document.getElementById('toggleAcross');
+var el = document.getElementById('toggles');
+var boxes = el.getElementsByTagName('input');
 
-chrome.extension.getBackgroundPage().console.log("in popup");
-
-toggleAcross.onclick = function(element) {
-	chrome.extension.getBackgroundPage().console.log("in toggleAcross");
-	try {
-	  chrome.storage.local.get("acrossVisible", function(data) {
-        chrome.storage.local.set({acrossVisible: !data.acrossVisible});
-        console.log("setting acrossVisible to " + !data.acrossVisible);
-      });	  
-      chrome.extension.getBackgroundPage().console.log("clicked toggle-across");
-	} catch(err) {
-		chrome.extension.getBackgroundPage().console.log(err);
-	}
-	chrome.extension.getBackgroundPage().console.log("after call");
+for (var i=0, len=boxes.length; i<len; i++) {
+  if ( boxes[i].type === 'checkbox' ) {
+    boxes[i].onclick = toggle;    
+  };
 };
 
-let toggleDown = document.getElementById('toggleDown');
-
-toggleDown.onclick = function(element) {
-	chrome.extension.getBackgroundPage().console.log("in toggleDown");
-	try {
-	  chrome.storage.local.get("downVisible", function(data) {
-        chrome.storage.local.set({downVisible: !data.downVisible});
-        console.log("setting downVisible to " + !data.downVisible);
-      });
-      chrome.extension.getBackgroundPage().console.log("clicked toggle-down");
-	} catch(err) {
-		chrome.extension.getBackgroundPage().console.log(err);
-	}
-	chrome.extension.getBackgroundPage().console.log("after call");
+function toggle(box) {
+  var which = this.value;
+  var hide = this.checked;
+  console.log("setting " + which + " to " + !hide);
+  var obj = {};
+  obj[which] = !hide;
+  chrome.storage.local.set(obj);
 };
 
-function refreshChecks() {
-  chrome.extension.getBackgroundPage().console.log("in refreshChecks");
-  chrome.storage.local.get("acrossVisible", function(data) {
-    chrome.extension.getBackgroundPage().console.log("acrossVisible is " + data.acrossVisible);
-    toggleAcross.checked = !data.acrossVisible;    
-  });
-  chrome.storage.local.get("downVisible", function(data) {
-    chrome.extension.getBackgroundPage().console.log("downVisible is " + data.downVisible);
-    toggleDown.checked = !data.downVisible;
+function refreshChecks() {  
+  var el = document.getElementById('toggles');  
+  var boxes = el.getElementsByTagName('input');  
+  for (var i=0, len=boxes.length; i<len; i++) {
+    if ( boxes[i].type === 'checkbox' ) {
+      initiateBox(boxes[i]);
+    };
+  };
+};
+
+function initiateBox(box) {
+  var which = box.value;
+  chrome.storage.local.get(which, function(data) {
+    box.checked = !data[which];
+    console.log("setting " + which + " to " + !data.which);
   });
 };
 


### PR DESCRIPTION
Changed the popup to have a similar dry-ed out implementation to the options page, in anticipation of eventually customizing contents based on which puzzle-type it shows for, i.e. acrostic doesn't have down/across clues